### PR TITLE
added missing ctypes import to run.py

### DIFF
--- a/Sickle/modules/dev/run.py
+++ b/Sickle/modules/dev/run.py
@@ -5,6 +5,7 @@ run: execute the shellcode on either windows or unix
 '''
 
 import os
+import ctypes
 from ctypes import CDLL, c_char_p, c_void_p, memmove, cast, CFUNCTYPE
 
 class module():


### PR DESCRIPTION
I've only been using the run module.  This fixes that module in particular.  I didn't investigate any others for similar bugs. 

Thanks for this project, the run module is awesome! 