### PR TITLE
Move shebang to top of file

### DIFF
--- a/sickle.py
+++ b/sickle.py
@@ -1,10 +1,10 @@
+#!/usr/bin/env python3
+
 '''
 
 sickle.py: this script runs sickle
 
 '''
-
-#!/usr/bin/env python3
 
 from Sickle import __main__
 


### PR DESCRIPTION
This will fix the following issue:
```
$ ./sickle.py
./sickle.py: line 5: $'\n\nsickle.py: this script runs sickle\n\n': command not found
./sickle.py: line 9: from: command not found
./sickle.py: line 12: syntax error: unexpected end of file
```